### PR TITLE
use C++11 new features instead of boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
-language: c
+language: c cpp
+
+compiler:
+  - gcc
+  - clang
 
 before_install:
           - sudo apt-get update -qq
           - sudo apt-get install -y automake make libtool autoconf rpm cmake libssl-dev libxml2-dev libboost-all-dev libstring-crc32-perl 
+
+install:
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang
 
 script: mkdir ../build && cd ../build && cmake ../OpenExanodes/ -DWITH_UT_ROOT=FALSE && make -j4 && ctest -V
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ if (NOT DEFAULT_FORCED)
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O0 -ggdb -DRELEASE -D_FORTIFY_SOURCE=2" CACHE STRING "Release with debug C flags" FORCE)
     set(CMAKE_C_FLAGS_COVERAGE "-ggdb -fprofile-arcs -ftest-coverage" CACHE STRING "Coverage C flags" FORCE)
 
-    set(CMAKE_CXX_FLAGS "-Wall -fno-strict-aliasing -Werror" CACHE STRING "CXX flags" FORCE)
+    set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fno-strict-aliasing -Werror" CACHE STRING "CXX flags" FORCE)
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb -DDEBUG" CACHE STRING "Debug CXX flags" FORCE)
     set(CMAKE_CXX_FLAGS_RELEASE "-O2 -ggdb -DRELEASE" CACHE STRING "Release CXX flags" FORCE)
     set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os" CACHE STRING "Minisize release CXX flags" FORCE)

--- a/ui/cli/src/command.cpp
+++ b/ui/cli/src/command.cpp
@@ -36,7 +36,7 @@
 #endif
 
 using boost::lexical_cast;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 using std::map;
 using std::placeholders::_1;
@@ -213,7 +213,7 @@ void Command::add_option(const char short_opt,
             "Option config error, short option -" + std::string(1, short_opt)
             + " already reserved.");
 
-    boost::shared_ptr<CommandOption> sp(new CommandOption(short_opt,
+    std::shared_ptr<CommandOption> sp(new CommandOption(short_opt,
                                                           long_opt,
                                                           description,
                                                           param_groups,
@@ -244,7 +244,7 @@ void Command::add_arg(const std::string &arg_name,
                       const std::string &default_value,
                       bool multiple)
 {
-    boost::shared_ptr<CommandArg> sp(new CommandArg(_args.size(),
+    std::shared_ptr<CommandArg> sp(new CommandArg(_args.size(),
                                                     arg_name,
                                                     param_groups,
                                                     hidden,
@@ -265,7 +265,7 @@ void Command::add_see_also(const std::string &see_also)
 }
 
 
-void Command::add_to_param_groups(const boost::shared_ptr<CommandParam> &param)
+void Command::add_to_param_groups(const std::shared_ptr<CommandParam> &param)
 {
     if (!param->is_mandatory())
         return;
@@ -416,13 +416,13 @@ void Command::parse()
 
 struct CommandParamCmp
 {
-    bool operator ()(const boost::shared_ptr<CommandParam> &op1,
-                     const boost::shared_ptr<CommandParam> &op2)
+    bool operator ()(const std::shared_ptr<CommandParam> &op1,
+                     const std::shared_ptr<CommandParam> &op2)
     {
-        boost::shared_ptr<CommandArg> arg1 =
-            boost::dynamic_pointer_cast<CommandArg>(op1);
-        boost::shared_ptr<CommandArg> arg2 =
-            boost::dynamic_pointer_cast<CommandArg>(op2);
+        std::shared_ptr<CommandArg> arg1 =
+            std::dynamic_pointer_cast<CommandArg>(op1);
+        std::shared_ptr<CommandArg> arg2 =
+            std::dynamic_pointer_cast<CommandArg>(op2);
 
         if (arg1.get() == NULL && arg2.get() != NULL)
             return true;
@@ -431,10 +431,10 @@ struct CommandParamCmp
 
         if (arg1.get() == NULL && arg2.get() == NULL)
         {
-            boost::shared_ptr<CommandOption> opt1 =
-                boost::dynamic_pointer_cast<CommandOption>(op1);
-            boost::shared_ptr<CommandOption> opt2 =
-                boost::dynamic_pointer_cast<CommandOption>(op2);
+            std::shared_ptr<CommandOption> opt1 =
+                std::dynamic_pointer_cast<CommandOption>(op1);
+            std::shared_ptr<CommandOption> opt2 =
+                std::dynamic_pointer_cast<CommandOption>(op2);
 
             char c1(opt1->get_short_opt());
             char c2(opt2->get_short_opt());
@@ -474,7 +474,7 @@ void Command::generate_valid_param_combinations()
             for (size_t i = 0; i < group.size(); ++i)
             {
                 CommandParams nco(co);
-                boost::shared_ptr<CommandParam> gco = group.at(i);
+                std::shared_ptr<CommandParam> gco = group.at(i);
 
                 /* check that this opt is not in a param group */
                 /* from a previously chosen param */
@@ -553,7 +553,7 @@ void Command::check_provided_params(const std::map<char, std::string> &opt_args,
         if (oit == _options.end())
             throw CommandException("Illegal option");
 
-        boost::shared_ptr<CommandOption> option(oit->second);
+        std::shared_ptr<CommandOption> option(oit->second);
         if (option->is_arg_expected() && it->second.empty())
         {
             std::stringstream msg;
@@ -592,7 +592,7 @@ void Command::check_provided_params(const std::map<char, std::string> &opt_args,
         if (ait == _args.end())
             throw CommandException("Unexpected extra argument '" + (*it) + "'.");
 
-        boost::shared_ptr<CommandArg> arg(ait->second);
+        std::shared_ptr<CommandArg> arg(ait->second);
         for (std::set<int>::const_iterator mit = arg->get_param_groups().begin();
              mit != arg->get_param_groups().end(); ++mit)
         {

--- a/ui/cli/src/command.cpp
+++ b/ui/cli/src/command.cpp
@@ -832,7 +832,7 @@ shared_ptr<AdmindMessage> Command::send_command(const AdmindCommand &command,
         client.send_leader(command, nodes,
                            bind(&Command::handle_inprogress, this, _1),
                            bind(handle_progressive_payload, _1,
-                                boost::ref(payload)),
+                                std::ref(payload)),
                            bind(leader_done, _1, &message),
                            bind(leader_warning, _1, _2, &warnings),
                            bind(leader_error, _1, &error_message),
@@ -949,7 +949,7 @@ shared_ptr<AdmindMessage> Command::send_admind_to_node(
 
     client.send_node(command, node,
                      bind(&Command::handle_inprogress, this, _1),
-                     bind(handle_progressive_payload, _1, boost::ref(payload)),
+                     bind(handle_progressive_payload, _1, std::ref(payload)),
                      bind(to_node_done, _1, &message),
                      bind(to_node_error, _1, node),
                      _timeout);
@@ -1067,11 +1067,11 @@ unsigned int Command::send_admind_by_node(AdmindCommand &command,
                       it->c_str());
         client.send_node(command, *it,
                          bind(&Command::handle_inprogress, this, _1),
-                         /* Careful passing a ref thru bind needs use of boost::ref() */
+                         /* Careful passing a ref thru bind needs use of std::ref() */
                          bind(handle_progressive_payload, _1,
-                              boost::ref(payload)),
+                              std::ref(payload)),
                          bind(&Command::by_node_done, this, _1, *it,
-                              boost::ref(payload), &errors, func),
+                              std::ref(payload), &errors, func),
                          bind(by_node_error, _1, *it, &errors, func),
                          _timeout);
     }

--- a/ui/cli/src/command.h
+++ b/ui/cli/src/command.h
@@ -13,6 +13,7 @@
 #include "ui/cli/src/command_arg.h"
 #include "ui/common/include/exabase.h"
 #include "ui/common/include/notifier.h"
+#include <functional>
 
 
 
@@ -70,12 +71,12 @@ public:
     virtual ~Command();
 
 
-    typedef boost::function < void (const std::string & node,
+    typedef std::function < void (const std::string & node,
                                     exa_error_code error_code,
                                     boost::shared_ptr<const AdmindMessage>)
 	> by_node_func;
 
-    typedef boost::function < void (const std::string & node,
+    typedef std::function < void (const std::string & node,
                                     AdmindCommand & command) >
     per_node_modify_func;
 

--- a/ui/cli/src/command.h
+++ b/ui/cli/src/command.h
@@ -64,7 +64,7 @@ class Command
 {
 public:
 
-    typedef boost::shared_ptr<Command>(*factory_t)(int argc, char *argv[]);
+    typedef std::shared_ptr<Command>(*factory_t)(int argc, char *argv[]);
 
     Command(int argc, char *argv[]);
 
@@ -73,7 +73,7 @@ public:
 
     typedef std::function < void (const std::string & node,
                                     exa_error_code error_code,
-                                    boost::shared_ptr<const AdmindMessage>)
+                                    std::shared_ptr<const AdmindMessage>)
 	> by_node_func;
 
     typedef std::function < void (const std::string & node,
@@ -81,17 +81,17 @@ public:
     per_node_modify_func;
 
 
-    exa_error_code get_param(boost::shared_ptr<xmlDoc> &cfg);
-    exa_error_code get_configclustered(boost::shared_ptr<xmlDoc> &cfg);
+    exa_error_code get_param(std::shared_ptr<xmlDoc> &cfg);
+    exa_error_code get_configclustered(std::shared_ptr<xmlDoc> &cfg);
 
     void display_usage_from_pod(std::string &msg);
 
-    boost::shared_ptr<AdmindMessage> send_command(const AdmindCommand &command,
+    std::shared_ptr<AdmindMessage> send_command(const AdmindCommand &command,
                                                   const std::string &summary,
                                                   exa_error_code &error_code,
                                                   std::string &error_message);
 
-    boost::shared_ptr<AdmindMessage> send_admind_to_node(const std::string &node,
+    std::shared_ptr<AdmindMessage> send_admind_to_node(const std::string &node,
                                                          AdmindCommand &command,
                                                          exa_error_code &error_code);
 
@@ -229,7 +229,7 @@ protected:
 
 private:
 
-    void add_to_param_groups(const boost::shared_ptr<CommandParam>& param);
+    void add_to_param_groups(const std::shared_ptr<CommandParam>& param);
     void generate_valid_param_combinations();
     void check_provided_params(const std::map<char, std::string> &opt_args,
 			       const std::vector<std::string> &non_opt_args) const;
@@ -263,7 +263,7 @@ private:
     bool _in_progress_hidden;  //!< whether or not to display in progress messages
 
     SelectNotifier notifier;
-    boost::shared_ptr<Line>line;
+    std::shared_ptr<Line>line;
     std::string in_progress_source;
 
 };
@@ -273,10 +273,10 @@ private:
 EXA_BASIC_EXCEPTION_DECL(CommandException, exa::Exception);
 
 
-template<class T>boost::shared_ptr<Command>
+template<class T>std::shared_ptr<Command>
 command_factory(int argc, char *argv[])
 {
-    boost::shared_ptr<Command> inst(new T(argc, argv));
+    std::shared_ptr<Command> inst(new T(argc, argv));
     inst->init_options();
     inst->init_see_alsos();
     inst->parse ();

--- a/ui/cli/src/command_arg.h
+++ b/ui/cli/src/command_arg.h
@@ -43,7 +43,7 @@ public:
 
 
 
-typedef std::map<int,boost::shared_ptr<CommandArg> > CommandArgs;
+typedef std::map<int,std::shared_ptr<CommandArg> > CommandArgs;
 
 
 #endif

--- a/ui/cli/src/command_option.h
+++ b/ui/cli/src/command_option.h
@@ -63,7 +63,7 @@ struct CommandOptionCmp
 
 
 
-typedef std::map<char,boost::shared_ptr<CommandOption>,CommandOptionCmp> CommandOptions;
+typedef std::map<char,std::shared_ptr<CommandOption>,CommandOptionCmp> CommandOptions;
 
 
 #endif

--- a/ui/cli/src/command_param.h
+++ b/ui/cli/src/command_param.h
@@ -9,10 +9,10 @@
 #define __COMMAND_PARAM_H__
 
 
+#include <memory>
 #include <string>
 #include <set>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 
 
@@ -49,7 +49,7 @@ public:
 };
 
 
-typedef std::vector<boost::shared_ptr<CommandParam> > CommandParams;
+typedef std::vector<std::shared_ptr<CommandParam> > CommandParams;
 
 std::ostream &operator << (std::ostream & os, const CommandParam &op);
 

--- a/ui/cli/src/exa_clcreate.cpp
+++ b/ui/cli/src/exa_clcreate.cpp
@@ -49,7 +49,7 @@
 #define ANY_DISKS_OF_NODE "any"
 
 using boost::lexical_cast;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::vector;
 using std::map;
 using std::set;
@@ -153,7 +153,7 @@ struct getnodedisks_filter : private boost::noncopyable
      *         EXA_SUCCESS to continue command processing to next nodes
      */
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {
@@ -208,7 +208,7 @@ struct getclustername_filter : private boost::noncopyable
 
 
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {
@@ -276,7 +276,7 @@ struct clcreate_filter : private boost::noncopyable
 
 
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {

--- a/ui/cli/src/exa_clcreate.cpp
+++ b/ui/cli/src/exa_clcreate.cpp
@@ -681,7 +681,7 @@ void exa_clcreate::run()
         struct getnodedisks_filter command_filter;
 
         send_admind_by_node(command_getdisks, node_set,
-                            boost::ref(command_filter));
+                            std::ref(command_filter));
         if (command_filter.got_error)
             throw CommandException("Can't retrieve available disks.");
 
@@ -876,7 +876,7 @@ void exa_clcreate::run()
     getclustername_filter mygetclusternamefilter;
 
     send_admind_by_node(command_getname, nodelist,
-                        boost::ref(mygetclusternamefilter));
+                        std::ref(mygetclusternamefilter));
 
     /* Display the global status */
     if (!mygetclusternamefilter.filter_got_error)
@@ -922,7 +922,7 @@ void exa_clcreate::run()
     clcreate_filter myclcreatefilter(*line);
 
     unsigned int nb_error(send_admind_by_node(command_create, nodelist,
-                                              boost::ref(
+                                              std::ref(
                                                   myclcreatefilter),
                                               set_hostname_override));
 

--- a/ui/cli/src/exa_cldelete.cpp
+++ b/ui/cli/src/exa_cldelete.cpp
@@ -86,7 +86,7 @@ struct cldelete_filter : private boost::noncopyable
 
 
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {

--- a/ui/cli/src/exa_cldelete.cpp
+++ b/ui/cli/src/exa_cldelete.cpp
@@ -184,7 +184,7 @@ void exa_cldelete::run()
     cldelete_filter myfilter1;
 
     send_admind_by_node(command_getname, exa.get_hostnames(),
-                                      boost::ref(myfilter1));
+                                      std::ref(myfilter1));
 
     /* Display the global status */
     if (!myfilter1.filter_got_error)
@@ -210,7 +210,7 @@ void exa_cldelete::run()
     exa_cli_info("%-" exa_mkstr(FMT_TYPE_H1) "s ",
                  "Deleting the initialization file");
 
-    send_admind_by_node(command_delete, exa.get_hostnames(), boost::ref(myfilter2));
+    send_admind_by_node(command_delete, exa.get_hostnames(), std::ref(myfilter2));
 
     /* Display the global status */
     if (!myfilter2.filter_got_error)

--- a/ui/cli/src/exa_clinfo.cpp
+++ b/ui/cli/src/exa_clinfo.cpp
@@ -29,7 +29,7 @@ using std::string;
 using std::set;
 using std::multiset;
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using boost::format;
 using boost::lexical_cast;
 

--- a/ui/cli/src/exa_clinfo.h
+++ b/ui/cli/src/exa_clinfo.h
@@ -74,21 +74,21 @@ public:
     bool iscsi_details;
 
     uint node_column_width;
-    boost::shared_ptr<xmlDoc> config_ptr;
+    std::shared_ptr<xmlDoc> config_ptr;
     std::string filter_only;
 
  protected:
-    void exa_display_clinfo(boost::shared_ptr<xmlDoc>);
+    void exa_display_clinfo(std::shared_ptr<xmlDoc>);
 
     void reset_all_info_flags();
 
-    boost::shared_ptr<xmlDoc> get_config(exa_error_code &error_code, bool &in_recovery);
+    std::shared_ptr<xmlDoc> get_config(exa_error_code &error_code, bool &in_recovery);
     void display_node_status(const std::set<std::string> &nodelist,
                              const std::string& color,
                              const std::string& status);
     std::string display_nodes(const std::set<std::string> &nodelist,
                               uint indent = 0);
-    std::set<std::string> get_downnodes(boost::shared_ptr<xmlDoc> config_doc_ptr,
+    std::set<std::string> get_downnodes(std::shared_ptr<xmlDoc> config_doc_ptr,
                                         std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &);
     std::set<std::string> nodelist_remove(std::set<std::string> &list1,
                                           std::set<std::string> &list2);
@@ -96,39 +96,39 @@ public:
                                              std::set<std::string> &list2);
     std::set<std::string> nodestring_split(const char *instr);
 
-    void exa_display_softs(boost::shared_ptr<xmlDoc>,
+    void exa_display_softs(std::shared_ptr<xmlDoc>,
                            std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &,
                            bool license_has_ha);
 #ifdef WITH_MONITORING
-    void exa_display_monitoring(boost::shared_ptr<xmlDoc>);
+    void exa_display_monitoring(std::shared_ptr<xmlDoc>);
 #endif
-    void exa_display_rdevs(boost::shared_ptr<xmlDoc>);
-    int  exa_display_modules(boost::shared_ptr<xmlDoc>,
+    void exa_display_rdevs(std::shared_ptr<xmlDoc>);
+    int  exa_display_modules(std::shared_ptr<xmlDoc>,
                              std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &,
                              std::string &resultstring);
-    int  exa_display_daemons(boost::shared_ptr<xmlDoc>,
+    int  exa_display_daemons(std::shared_ptr<xmlDoc>,
                              std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &,
                              std::string &resultstring);
-    void exa_display_token_manager(boost::shared_ptr<xmlDoc>,
+    void exa_display_token_manager(std::shared_ptr<xmlDoc>,
                                    std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &);
 
-    void exa_display_groups(boost::shared_ptr<xmlDoc>,
+    void exa_display_groups(std::shared_ptr<xmlDoc>,
                             std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &);
-    void exa_display_components_in_group(boost::shared_ptr<xmlDoc>,
+    void exa_display_components_in_group(std::shared_ptr<xmlDoc>,
                                          xmlNodePtr groupptr);
     void exa_display_group_configurations(std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &grplist);
-    void exa_display_volume(boost::shared_ptr<xmlDoc> config_doc_ptr,
+    void exa_display_volume(std::shared_ptr<xmlDoc> config_doc_ptr,
                             xmlNodePtr &, const std::string &group_status);
-    void exa_display_volumes_status(boost::shared_ptr<xmlDoc> config_doc_ptr,
+    void exa_display_volumes_status(std::shared_ptr<xmlDoc> config_doc_ptr,
                                     std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &nodelist);
 
     void exa_display_export_status(xmlNodePtr volume_node, xmlNodePtr export_node,
 				   const std::string& group_status);
 
-    void exa_display_one_fs_status(boost::shared_ptr<xmlDoc> config_doc_ptr,
+    void exa_display_one_fs_status(std::shared_ptr<xmlDoc> config_doc_ptr,
                                    xmlNodePtr fs, const std::string& name);
-    void exa_display_gulm_nodes(boost::shared_ptr<xmlDoc>config_doc_ptr);
-    void exa_display_fs_status(boost::shared_ptr<xmlDoc>,
+    void exa_display_gulm_nodes(std::shared_ptr<xmlDoc>config_doc_ptr);
+    void exa_display_fs_status(std::shared_ptr<xmlDoc>,
                                std::set<xmlNodePtr, exa_cmp_xmlnode_lt> &);
 
     bool summSize(xmlNodeSetPtr, uint64_t *, uint64_t *);
@@ -136,7 +136,7 @@ public:
 	                    uint rdevpath_maxlen);
     void display_total(uint64_t sizeT, uint disk_count,
 	               uint rdevpath_maxlen);
-    void init_column_width(boost::shared_ptr<xmlDoc> config_doc_ptr);
+    void init_column_width(std::shared_ptr<xmlDoc> config_doc_ptr);
     std::string exa_format_human_readable_string(const char* config_string, bool force_kilo);
 };
 

--- a/ui/cli/src/exa_cllicense.cpp
+++ b/ui/cli/src/exa_cllicense.cpp
@@ -25,7 +25,7 @@
 #include <boost/lexical_cast.hpp>
 
 using boost::lexical_cast;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 const std::string exa_cllicense::OPT_ARG_FILENAME(Command::Boldify("FILENAME"));
@@ -82,7 +82,7 @@ struct getclustername_filter_t : private boost::noncopyable
      *
      */
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {
@@ -147,7 +147,7 @@ public:
      *
      */
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {

--- a/ui/cli/src/exa_cllicense.cpp
+++ b/ui/cli/src/exa_cllicense.cpp
@@ -193,7 +193,7 @@ void exa_cllicense::run()
     getclustername_filter_t getclustername_filter(exa.get_cluster());
 
     send_admind_by_node(command_getname, exa.get_hostnames(),
-                        boost::ref(getclustername_filter));
+                        std::ref(getclustername_filter));
 
     /* Display the global status */
     if (getclustername_filter.got_error)
@@ -239,7 +239,7 @@ void exa_cllicense::run()
 
     /* Send the command and receive the response */
     send_admind_by_node(setlicense_command, exa.get_hostnames(),
-                        boost::ref(setlicense_filter));
+                        std::ref(setlicense_filter));
 
     if (setlicense_filter.got_error)
     {

--- a/ui/cli/src/exa_clnodeadd.cpp
+++ b/ui/cli/src/exa_clnodeadd.cpp
@@ -25,7 +25,7 @@
 using boost::lexical_cast;
 using std::set;
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 const std::string exa_clnodeadd::OPT_ARG_CONFIG_FILE(Command::Boldify("FILE"));

--- a/ui/cli/src/exa_clnodedel.cpp
+++ b/ui/cli/src/exa_clnodedel.cpp
@@ -12,7 +12,7 @@
 #include "ui/common/include/admindmessage.h"
 #include "ui/common/include/cli_log.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 const std::string exa_clnodedel::OPT_ARG_NODE_HOSTNAME(Command::Boldify(

--- a/ui/cli/src/exa_clnoderecover.cpp
+++ b/ui/cli/src/exa_clnoderecover.cpp
@@ -20,7 +20,7 @@
 #include <fstream>
 
 using std::string;
-using boost::shared_ptr;
+using std::shared_ptr;
 
 const std::string exa_clnoderecover::OPT_ARG_NODE_HOSTNAMES(Command::Boldify(
                                                                 "HOSTNAMES"));

--- a/ui/cli/src/exa_clnodestart.cpp
+++ b/ui/cli/src/exa_clnodestart.cpp
@@ -150,7 +150,7 @@ void exa_clnodestart::run()
 
     clinit_filter myfilter;
     nr_errors = send_admind_by_node(command_init, nodelist,
-                                    boost::ref(myfilter));
+                                    std::ref(myfilter));
 
     if (nr_errors)
     {

--- a/ui/cli/src/exa_clnodestart.cpp
+++ b/ui/cli/src/exa_clnodestart.cpp
@@ -58,7 +58,7 @@ struct clinit_filter : private boost::noncopyable
 
 
     void operator ()(const std::string &node, exa_error_code err_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (err_code)
         {

--- a/ui/cli/src/exa_clnodestop.cpp
+++ b/ui/cli/src/exa_clnodestop.cpp
@@ -258,7 +258,7 @@ void exa_clnodestop::run()
 
     exa_cli_info("%s\n", msg_str.c_str());
     send_admind_by_node(command_stop, exa.get_hostnames(),
-                                    boost::ref(stop_filter));
+                                    std::ref(stop_filter));
 
     if (stop_filter.got_error)
     {
@@ -279,7 +279,7 @@ void exa_clnodestop::run()
     clshutdown_filter shutdown_filter(exa, nodelist);
 
     send_admind_by_node(command_shutdown, exa.get_hostnames(),
-                                    boost::ref(shutdown_filter));
+                                    std::ref(shutdown_filter));
 
     exa_cli_info("%-" exa_mkstr(FMT_TYPE_H1) "s ", "Stopping requested nodes");
 

--- a/ui/cli/src/exa_clnodestop.cpp
+++ b/ui/cli/src/exa_clnodestop.cpp
@@ -92,7 +92,7 @@ struct clnodestop_filter : private boost::noncopyable
 
 
     void operator ()(const std::string &hostname, exa_error_code err_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         std::string nodename = exa.to_nodename(hostname);
 
@@ -151,7 +151,7 @@ struct clshutdown_filter : private boost::noncopyable
 
 
     void operator ()(const std::string &hostname, exa_error_code err_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         std::string nodename = exa.to_nodename(hostname);
 

--- a/ui/cli/src/exa_clreconnect.cpp
+++ b/ui/cli/src/exa_clreconnect.cpp
@@ -13,7 +13,7 @@
 #include "ui/common/include/admindmessage.h"
 #include "ui/common/include/cli_log.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 const std::string exa_clreconnect::OPT_ARG_NODE_HOSTNAME(Command::Boldify(

--- a/ui/cli/src/exa_clstart.cpp
+++ b/ui/cli/src/exa_clstart.cpp
@@ -184,7 +184,7 @@ void exa_clstart::run()
                      FMT_TYPE_H1) "s\n",
                  "Initializing the cluster (Please wait):");
 
-    send_admind_by_node(command_init, nodelist, boost::ref(myfilter));
+    send_admind_by_node(command_init, nodelist, std::ref(myfilter));
 
     /* Display the global status */
     if (myfilter.nb_node_unreachable

--- a/ui/cli/src/exa_clstart.cpp
+++ b/ui/cli/src/exa_clstart.cpp
@@ -12,7 +12,7 @@
 #include "ui/common/include/admindmessage.h"
 #include "ui/common/include/cli_log.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 exa_clstart::exa_clstart(int argc, char *argv[])

--- a/ui/cli/src/exa_clstats.cpp
+++ b/ui/cli/src/exa_clstats.cpp
@@ -33,7 +33,7 @@
 #define NAN _Nan._Double
 #endif
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 using std::set;
 using std::vector;
@@ -1531,7 +1531,7 @@ void exa_clstats::run()
     AdmindCommand command("clstats", exa.get_cluster_uuid());
     command.add_param("reset", reset ? "TRUE" : "FALSE");
 
-    boost::shared_ptr<AdmindMessage> message(
+    std::shared_ptr<AdmindMessage> message(
         send_command(command, msg_str, error_code, error_msg));
 
     if (!message)

--- a/ui/cli/src/exa_cltrace.cpp
+++ b/ui/cli/src/exa_cltrace.cpp
@@ -170,7 +170,7 @@ static void sort_components()
 struct cltrace_filter : private boost::noncopyable
 {
     void operator ()(const std::string &node, exa_error_code err_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (err_code)
         {

--- a/ui/cli/src/exa_cltrace.cpp
+++ b/ui/cli/src/exa_cltrace.cpp
@@ -231,7 +231,7 @@ void exa_cltrace::run()
 
     cltrace_filter myfilter;
     nr_errors = send_admind_by_node(command, nodelist,
-                                    boost::ref(myfilter));
+                                    std::ref(myfilter));
 
     if (nr_errors)
         exa_cli_error(

--- a/ui/cli/src/exa_cltune.cpp
+++ b/ui/cli/src/exa_cltune.cpp
@@ -242,7 +242,7 @@ exa_error_code exa_cltune::send_single_param(string param, string value)
     exa_cli_info("%-" exa_mkstr(FMT_TYPE_H1) "s ",
                  "Setting parameter:");
 
-    nb_error = send_admind_by_node(commandl, nodelist, boost::ref(myfilter));
+    nb_error = send_admind_by_node(commandl, nodelist, std::ref(myfilter));
 
     /* Display the global status */
     if (!myfilter.got_error)

--- a/ui/cli/src/exa_cltune.cpp
+++ b/ui/cli/src/exa_cltune.cpp
@@ -24,7 +24,7 @@
 #include <boost/lexical_cast.hpp>
 
 using boost::lexical_cast;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 
 /* TODO : grep all these constants and see if should be moved at an */
@@ -102,7 +102,7 @@ public:
 
 
     void operator ()(const std::string &node, exa_error_code error_code,
-                     boost::shared_ptr<const AdmindMessage> message)
+                     std::shared_ptr<const AdmindMessage> message)
     {
         switch (error_code)
         {

--- a/ui/cli/src/exa_fscreate.h
+++ b/ui/cli/src/exa_fscreate.h
@@ -38,7 +38,7 @@ protected:
     void parse_opt_args (const std::map<char, std::string>& opt_args);
 
 private:
-    boost::shared_ptr<AdmindCommand> generate_config_command();
+    std::shared_ptr<AdmindCommand> generate_config_command();
 
     exa_error_code create_and_send_xml_command();
 

--- a/ui/cli/src/exa_fstune.cpp
+++ b/ui/cli/src/exa_fstune.cpp
@@ -16,7 +16,7 @@
 #include "ui/common/include/cli_log.h"
 
 using std::string;
-using boost::shared_ptr;
+using std::shared_ptr;
 
 const std::string exa_fstune::ARG_PARAMETER_PARAMETER(Command::Boldify(
                                                           "PARAMETER"));

--- a/ui/cli/src/exa_vltune.cpp
+++ b/ui/cli/src/exa_vltune.cpp
@@ -19,7 +19,7 @@
 #include "ui/common/include/common_utils.h"
 
 using std::string;
-using boost::shared_ptr;
+using std::shared_ptr;
 using boost::lexical_cast;
 
 const std::string exa_vltune::ARG_PARAMETER_PARAMETER(Command::Boldify(

--- a/ui/cli/src/info_help.cpp
+++ b/ui/cli/src/info_help.cpp
@@ -8,7 +8,6 @@
 #include "ui/cli/src/command.h"
 #include <iostream>
 
-#include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/ui/cli/src/info_help.cpp
+++ b/ui/cli/src/info_help.cpp
@@ -223,8 +223,8 @@ void Command::dump_synopsis(std::ostream &out, bool show_hidden) const
         for (CommandParams::const_iterator it2 = it->begin();
              it2 != it->end(); ++it2)
         {
-            boost::shared_ptr<CommandOption> opt =
-                boost::dynamic_pointer_cast<CommandOption>(*it2);
+            std::shared_ptr<CommandOption> opt =
+                std::dynamic_pointer_cast<CommandOption>(*it2);
 
             if (opt.get() != NULL)
             {
@@ -234,8 +234,8 @@ void Command::dump_synopsis(std::ostream &out, bool show_hidden) const
                 continue;
             }
 
-            boost::shared_ptr<CommandArg> arg =
-                boost::dynamic_pointer_cast<CommandArg>(*it2);
+            std::shared_ptr<CommandArg> arg =
+                std::dynamic_pointer_cast<CommandArg>(*it2);
 
             if (arg.get() != NULL)
             {

--- a/ui/cli/src/info_pod.cpp
+++ b/ui/cli/src/info_pod.cpp
@@ -195,8 +195,8 @@ void Command::dump_synopsis(std::ostream &out, bool show_hidden) const
         for (CommandParams::const_iterator it2 = it->begin();
              it2 != it->end(); ++it2)
         {
-            boost::shared_ptr<CommandOption> opt =
-                boost::dynamic_pointer_cast<CommandOption>(*it2);
+            std::shared_ptr<CommandOption> opt =
+                std::dynamic_pointer_cast<CommandOption>(*it2);
             if (opt.get() != NULL)
             {
                 out << " --" << opt->get_long_opt();
@@ -204,8 +204,8 @@ void Command::dump_synopsis(std::ostream &out, bool show_hidden) const
                     out << " " << opt->get_arg_name();
                 continue;
             }
-            boost::shared_ptr<CommandArg> arg =
-                boost::dynamic_pointer_cast<CommandArg>(*it2);
+            std::shared_ptr<CommandArg> arg =
+                std::dynamic_pointer_cast<CommandArg>(*it2);
             if (arg.get() != NULL)
             {
                 if (!arg->is_mandatory())

--- a/ui/cli/src/info_pod.cpp
+++ b/ui/cli/src/info_pod.cpp
@@ -8,7 +8,6 @@
 #include "ui/cli/src/command.h"
 #include <iostream>
 
-#include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/ui/cli/src/info_referenceguide.cpp
+++ b/ui/cli/src/info_referenceguide.cpp
@@ -226,7 +226,7 @@ void Command::dump_synopsis(std::ostream &out, bool show_hidden) const
         for (CommandParams::const_iterator it2 = it->begin();
              it2 != it->end(); ++it2)
         {
-            boost::shared_ptr<CommandOption> opt =
+            std::shared_ptr<CommandOption> opt =
                 boost::dynamic_pointer_cast<CommandOption>(*it2);
 
             if (opt.get() != NULL)
@@ -242,7 +242,7 @@ void Command::dump_synopsis(std::ostream &out, bool show_hidden) const
                 continue;
             }
 
-            boost::shared_ptr<CommandArg> arg =
+            std::shared_ptr<CommandArg> arg =
                 boost::dynamic_pointer_cast<CommandArg>(*it2);
 
             if (arg.get() != NULL)

--- a/ui/cli/src/main.cpp
+++ b/ui/cli/src/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
             throw CommandException(EXA_ERR_CMD_PARSING);
         }
 
-        boost::shared_ptr<Command> cmd = (*factory)(argc, argv);
+        std::shared_ptr<Command> cmd = (*factory)(argc, argv);
         cmd->run();
     }
     catch (exa::Exception &e)

--- a/ui/cli/test/ut_exa_clinfo.cpp
+++ b/ui/cli/test/ut_exa_clinfo.cpp
@@ -11,7 +11,7 @@
 #include "ui/common/include/cli_log.h"
 #include "common/include/exa_config.h"
 #include "common/include/exa_constants.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <set>
 #include <string>
 #include <sstream>
@@ -104,7 +104,7 @@ extern std::stringstream __stdout;
 
 
 typedef
-void (exa_clinfo::*display_func_t)(boost::shared_ptr<xmlDoc>,
+void (exa_clinfo::*display_func_t)(std::shared_ptr<xmlDoc>,
         std::set<xmlNodePtr, exa_clinfo::exa_cmp_xmlnode_lt> &);
 
 /**
@@ -115,7 +115,7 @@ static void test_display_info(const std::string& expected_output,
                               display_func_t display_func)
 {
     // Build XML doc
-    boost::shared_ptr<xmlDoc> config(
+    std::shared_ptr<xmlDoc> config(
         xmlReadMemory(
         xml_input.c_str(), xml_input.size(),
         NULL, NULL, XML_PARSE_NOBLANKS | XML_PARSE_NOERROR | XML_PARSE_NOWARNING));

--- a/ui/common/include/admindclient.h
+++ b/ui/common/include/admindclient.h
@@ -8,8 +8,8 @@
 #ifndef __ADMINDCLIENT_H__
 #define __ADMINDCLIENT_H__
 
-#include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
+#include <functional>
 #include <set>
 
 class AdmindCommand;
@@ -22,9 +22,9 @@ class AdmindClient: private boost::noncopyable
 public:
   AdmindClient(Notifier &_notifier);
 
-  typedef boost::function<void(const AdmindMessage& message)> MessageFunc;
-  typedef boost::function<void(const std::string &info)> ErrorFunc;
-  typedef boost::function<void(const std::string &hostname,
+  typedef std::function<void(const AdmindMessage& message)> MessageFunc;
+  typedef std::function<void(const std::string &info)> ErrorFunc;
+  typedef std::function<void(const std::string &hostname,
 			       const std::string &info, int warn)
     > WarningFunc;
 

--- a/ui/common/include/admindcommand.h
+++ b/ui/common/include/admindcommand.h
@@ -15,7 +15,7 @@
 #include "common/include/uuid.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 #include <sstream>
 #include <stdexcept>
@@ -29,7 +29,7 @@ class AdmindCommand: private boost::noncopyable
 {
 private:
     const std::string name;
-    boost::shared_ptr<xmlDoc> xml_cmd;
+    std::shared_ptr<xmlDoc> xml_cmd;
     xmlNodePtr params;
 
 public:

--- a/ui/common/include/admindmessage.h
+++ b/ui/common/include/admindmessage.h
@@ -11,7 +11,7 @@
 #include <libxml/tree.h>
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 #include "common/include/exa_error.h"
@@ -71,7 +71,7 @@ public:
     return connected_node;
   }
 
-  boost::shared_ptr<xmlDoc> get_subtree() const;
+  std::shared_ptr<xmlDoc> get_subtree() const;
   std::string get_summary() const;
   std::string dump() const;
 
@@ -80,7 +80,7 @@ private:
    * const!), avoiding the accesoors, but because they are initialized
    * in the constructor body rather than in the initializer list (and
    * so, cannot be const), things have to be this way. Oh well. */
-  boost::shared_ptr<xmlDoc> xml_msg;
+  std::shared_ptr<xmlDoc> xml_msg;
   std::string payload_string;
   xmlNodePtr subtree;
   MessageType type;

--- a/ui/common/include/exabase.h
+++ b/ui/common/include/exabase.h
@@ -8,11 +8,11 @@
 #ifndef  __EXABASE_H__
 #define  __EXABASE_H__
 
-#include <boost/shared_ptr.hpp>
 #include <boost/utility.hpp>
 #include <libxml/tree.h>
 
 #include "common/include/exa_error.h"
+#include <memory>
 #include <set>
 
 class ClusterCache;
@@ -65,7 +65,7 @@ public:
   const std::string &to_nodename(const std::string &hostname) const;
 
 private:
-  boost::shared_ptr<ClusterCache> cluster;
+  std::shared_ptr<ClusterCache> cluster;
 
   exa_error_code config_cache_save(std::string &error_msg);
 

--- a/ui/common/include/notifier.h
+++ b/ui/common/include/notifier.h
@@ -8,9 +8,9 @@
 #ifndef __NOTIFIER_H__
 #define __NOTIFIER_H__
 
-#include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/weak_ptr.hpp>
+#include <functional>
 #include <list>
 #include <map>
 #include <queue>
@@ -19,8 +19,8 @@
 class Notifier: private boost::noncopyable
 {
 public:
-  typedef boost::function<void(int)> FdNotifyFunc;
-  typedef boost::function<void()> VoidFunc;
+  typedef std::function<void(int)> FdNotifyFunc;
+  typedef std::function<void()> VoidFunc;
 
   class Timer;
 

--- a/ui/common/include/notifier.h
+++ b/ui/common/include/notifier.h
@@ -9,10 +9,10 @@
 #define __NOTIFIER_H__
 
 #include <boost/noncopyable.hpp>
-#include <boost/weak_ptr.hpp>
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <queue>
 
 
@@ -30,7 +30,7 @@ public:
   virtual void add_write(int fd, FdNotifyFunc func) = 0;
   virtual void del_write(int fd) = 0;
 
-  virtual boost::shared_ptr<Timer> get_timer(unsigned int msec,
+  virtual std::shared_ptr<Timer> get_timer(unsigned int msec,
 					     VoidFunc func) = 0;
 
   virtual bool done();
@@ -54,7 +54,7 @@ public:
   virtual void del_read(int fd);
   virtual void add_write(int fd, FdNotifyFunc func);
   virtual void del_write(int fd);
-  virtual boost::shared_ptr<Timer> get_timer(unsigned int msec, VoidFunc func);
+  virtual std::shared_ptr<Timer> get_timer(unsigned int msec, VoidFunc func);
   virtual bool done();
 
 private:
@@ -63,14 +63,14 @@ private:
   class TimerComparator
   {
   public:
-    bool operator()(const boost::shared_ptr<Timer> &lhs,
-		    boost::shared_ptr<Timer> &rhs) const;
+    bool operator()(const std::shared_ptr<Timer> &lhs,
+		    std::shared_ptr<Timer> &rhs) const;
   };
 
   std::map<int, FdNotifyFunc> watches_read;
   std::map<int, FdNotifyFunc> watches_write;
-  std::priority_queue<boost::shared_ptr<Timer>,
-		      std::vector<boost::shared_ptr<Timer> >,
+  std::priority_queue<std::shared_ptr<Timer>,
+		      std::vector<std::shared_ptr<Timer> >,
 		      TimerComparator> timers;
 };
 

--- a/ui/common/src/admindclient.cpp
+++ b/ui/common/src/admindclient.cpp
@@ -7,7 +7,6 @@
  */
 #include "ui/common/include/admindclient.h"
 
-#include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <errno.h>
 #include <fcntl.h>
@@ -21,9 +20,12 @@
 #include "ui/common/src/admindclient_request.h"
 #include "ui/common/src/admindclient_seeker.h"
 
-using boost::bind;
+#include <functional>
+
 using boost::lexical_cast;
+using std::bind;
 using std::exception;
+using std::placeholders::_1;
 using std::runtime_error;
 using std::set;
 using std::string;

--- a/ui/common/src/admindclient_request.cpp
+++ b/ui/common/src/admindclient_request.cpp
@@ -11,11 +11,13 @@
 
 #include "ui/common/include/admindmessage.h"
 #include "os/include/os_network.h"
+#include <cassert>
+#include <cstring>
 #include <functional>
 
 #include <cstring>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::exception;
 using std::string;
 

--- a/ui/common/src/admindclient_request.cpp
+++ b/ui/common/src/admindclient_request.cpp
@@ -13,8 +13,9 @@
 #include "ui/common/include/admindmessage.h"
 #include "os/include/os_network.h"
 
+#include <cstring>
+
 using boost::bind;
-using boost::function;
 using boost::shared_ptr;
 using std::exception;
 using std::string;
@@ -32,7 +33,7 @@ AdmindClient::RequestImpl::RequestImpl(AdmindClient &_client,
 				       MessageFunc _progressive_payload,
 				       MessageFunc _done, ErrorFunc _error,
 				       unsigned int _timeout,
-				       function<void(RequestImpl*)> _cleanup):
+				       std::function<void(RequestImpl*)> _cleanup):
   client(_client),
   connected_node(_connected_node),
   command_name(cmd_name),

--- a/ui/common/src/admindclient_request.h
+++ b/ui/common/src/admindclient_request.h
@@ -10,6 +10,7 @@
 
 #include "ui/common/include/admindclient.h"
 #include "ui/common/include/notifier.h"
+#include <functional>
 
 
 class AdmindClient::Request : private boost::noncopyable
@@ -35,7 +36,7 @@ public:
                 MessageFunc _done,
                 ErrorFunc _error,
                 unsigned int _timeout,
-                boost::function < void (RequestImpl *) > _cleanup);
+                std::function < void (RequestImpl *) > _cleanup);
     ~RequestImpl();
 
 private:
@@ -63,7 +64,7 @@ private:
     MessageFunc progressive_payload;
     MessageFunc done;
     ErrorFunc error;
-    boost::function < void (RequestImpl *) > cleanup;
+    std::function < void (RequestImpl *) > cleanup;
     boost::shared_ptr<Notifier::Timer>timeout;
 };
 

--- a/ui/common/src/admindclient_request.h
+++ b/ui/common/src/admindclient_request.h
@@ -65,7 +65,7 @@ private:
     MessageFunc done;
     ErrorFunc error;
     std::function < void (RequestImpl *) > cleanup;
-    boost::shared_ptr<Notifier::Timer>timeout;
+    std::shared_ptr<Notifier::Timer>timeout;
 };
 
 

--- a/ui/common/src/admindclient_seeker.cpp
+++ b/ui/common/src/admindclient_seeker.cpp
@@ -13,6 +13,8 @@
 #include "ui/common/include/notifier.h"
 #include "os/include/os_network.h"
 
+#include <cstring>
+
 using boost::bind;
 using boost::shared_ptr;
 using std::exception;

--- a/ui/common/src/admindclient_seeker.cpp
+++ b/ui/common/src/admindclient_seeker.cpp
@@ -11,10 +11,11 @@
 #include "ui/common/include/notifier.h"
 #include "os/include/os_network.h"
 
+#include <cstring>
 #include <functional>
 #include <cstring>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::bind;
 using std::exception;
 using std::map;

--- a/ui/common/src/admindclient_seeker.cpp
+++ b/ui/common/src/admindclient_seeker.cpp
@@ -7,18 +7,18 @@
  */
 #include "ui/common/src/admindclient_seeker.h"
 
-#include <boost/bind.hpp>
-
 #include "ui/common/include/admindmessage.h"
 #include "ui/common/include/notifier.h"
 #include "os/include/os_network.h"
 
+#include <functional>
 #include <cstring>
 
-using boost::bind;
 using boost::shared_ptr;
+using std::bind;
 using std::exception;
 using std::map;
+using std::placeholders::_1;
 using std::set;
 using std::string;
 

--- a/ui/common/src/admindclient_seeker.h
+++ b/ui/common/src/admindclient_seeker.h
@@ -49,10 +49,10 @@ private:
   const WarningFunc warning;
   const ErrorFunc error;
 
-  boost::shared_ptr<Notifier::Timer> timeout;
+  std::shared_ptr<Notifier::Timer> timeout;
   std::map<std::string, int> connecting;
   std::map<std::string, int> connected;
-  boost::shared_ptr<RequestImpl> request;
+  std::shared_ptr<RequestImpl> request;
   bool finished;
   int err;
 };

--- a/ui/common/src/admindcommand.cpp
+++ b/ui/common/src/admindcommand.cpp
@@ -9,7 +9,6 @@
 
 #include <assert.h>
 #include <boost/lexical_cast.hpp>
-#include <boost/shared_ptr.hpp>
 #include <sstream>
 
 #include <libxml/xpath.h>
@@ -17,8 +16,10 @@
 #include "common/include/exa_conversion.h"
 #include "admind/src/xml_proto/xml_protocol_version.h"
 
+#include <memory>
+
 using boost::lexical_cast;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::runtime_error;
 using std::string;
 

--- a/ui/common/src/admindmessage.cpp
+++ b/ui/common/src/admindmessage.cpp
@@ -8,7 +8,6 @@
 #include "ui/common/include/admindmessage.h"
 
 #include <boost/lexical_cast.hpp>
-#include <boost/shared_ptr.hpp>
 #include <stdexcept>
 
 #include "ui/common/include/exa_conversion.hpp"
@@ -16,8 +15,10 @@
 #include "common/include/exa_config.h"
 #include "admind/src/xml_proto/xml_protocol_version.h"
 
+#include <memory>
+
 using boost::lexical_cast;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::exception;
 using std::runtime_error;
 using std::string;

--- a/ui/common/src/exabase.cpp
+++ b/ui/common/src/exabase.cpp
@@ -32,7 +32,7 @@
 #include "os/include/os_stdio.h"
 #include "os/include/os_user.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::exception;
 using std::set;
 using std::map;

--- a/ui/common/src/notifier.cpp
+++ b/ui/common/src/notifier.cpp
@@ -14,6 +14,8 @@
 #include "os/include/os_time.h"
 #include "os/include/os_network.h"
 
+#include <cstring>
+
 using boost::apply;
 using boost::shared_ptr;
 using std::list;

--- a/ui/common/src/notifier.cpp
+++ b/ui/common/src/notifier.cpp
@@ -7,8 +7,6 @@
  */
 #include "ui/common/include/notifier.h"
 
-#include <boost/bind.hpp>
-#include <boost/bind/apply.hpp>
 #include <errno.h>
 
 #include "os/include/os_time.h"
@@ -16,7 +14,6 @@
 
 #include <cstring>
 
-using boost::apply;
 using boost::shared_ptr;
 using std::list;
 using std::map;
@@ -169,12 +166,13 @@ static void analyze_select(int &rv, fd_set *fds,
   {
     if (FD_ISSET(it->first, fds))
     {
-      callbacks.push_back(bind(it->second, it->first));
+      callbacks.push_back(std::bind(it->second, it->first));
       --rv;
     }
   }
 
-  for_each(callbacks.begin(), callbacks.end(), apply<void>());
+  for (auto callback : callbacks)
+    callback();
 }
 
 

--- a/ui/common/src/notifier.cpp
+++ b/ui/common/src/notifier.cpp
@@ -12,9 +12,11 @@
 #include "os/include/os_time.h"
 #include "os/include/os_network.h"
 
+#include <algorithm>
+#include <cassert>
 #include <cstring>
 
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::list;
 using std::map;
 


### PR DESCRIPTION

The former code was using boost for features that are now available natively in c++11.

Removing unnecessary dependencies on boost may help maintenance
